### PR TITLE
Add extra log message to BasicAuthenticationFilter

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/www/BasicAuthenticationFilter.java
@@ -154,6 +154,9 @@ public class BasicAuthenticationFilter extends OncePerRequestFilter {
 				Authentication authResult = this.authenticationManager.authenticate(authRequest);
 				this.logger.debug(LogMessage.format("Authentication success: %s", authResult));
 				SecurityContextHolder.getContext().setAuthentication(authResult);
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug(LogMessage.format("Set SecurityContextHolder to %s", authResult));
+				}
 				this.rememberMeServices.loginSuccess(request, response, authResult);
 				onSuccessfulAuthentication(request, response, authResult);
 			}


### PR DESCRIPTION
It would be nice to mention that we are setting the SecurityContextHolder to the authentication result.
This aligns with the logs in `AbstractAuthenticationProcessingFilter`.
https://github.com/jzheaux/spring-security/blob/logging-restructure/web/src/main/java/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.java#L315

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
