### PR TITLE
Prevent NPE

### DIFF
--- a/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
+++ b/web/src/main/java/org/springframework/security/web/context/HttpSessionSecurityContextRepository.java
@@ -120,9 +120,8 @@ public class HttpSessionSecurityContextRepository implements SecurityContextRepo
 		if (context == null) {
 			context = generateNewContext();
 			if (this.logger.isTraceEnabled()) {
-				this.logger.trace(
-						LogMessage.format("Created %s since no SecurityContext was available from HttpSession %s",
-								context, httpSession.getId()));
+				this.logger.trace(LogMessage.format(
+						"Created %s since no SecurityContext was available from HttpSession %s", context, httpSession));
 			}
 		}
 		SaveToSessionResponseWrapper wrappedResponse = new SaveToSessionResponseWrapper(response, request,


### PR DESCRIPTION
It's possible that the httpSession is null, which leads to a NullPointerException if TRACE logs are enabled.

<!--
For Security Vulnerabilities, please use https://pivotal.io/security#reporting
-->

<!--
Before creating new features, we recommend creating an issue to discuss the feature. This ensures that everyone is on the same page before extensive work is done.

Thanks for contributing to Spring Security. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with gh-).
-->
